### PR TITLE
 修复 manifest.js handlers  问题

### DIFF
--- a/src/sketch/manifest.js
+++ b/src/sketch/manifest.js
@@ -5,7 +5,7 @@ const commandList = [
     name: 'Plugin Info',
     identifier: `${identifier}.system-info`,
     script: './app.ts',
-    handlers: 'toggleSystemInfoPanel',
+    handler: 'toggleSystemInfoPanel',
   },
 ];
 


### PR DESCRIPTION
官方教程中，`handlers` 是一个对象，而 `handler` 才是一个函数名，所以这里应该是手误写错了。


![image](https://user-images.githubusercontent.com/19297757/135744209-a6271929-c0c8-4671-a5e1-43576ae691c0.png)

![image](https://user-images.githubusercontent.com/19297757/135744215-caf37780-a173-4383-adc3-d07cecc4fc03.png)
